### PR TITLE
replace os.execute() with a safer variant

### DIFF
--- a/lua/spotify/auth.lua
+++ b/lua/spotify/auth.lua
@@ -38,6 +38,17 @@ local function await_tokens_refresh()
     end
 end
 
+--- Executes a shell command 'safely' and validates its success.
+---
+---@param cmd string: The shell command to be executed.
+---@throws error if the command execution fails.
+local function safe_execute(cmd)
+    local success, reason, code = os.execute(cmd)
+    if not success then
+        error(string.format("Command failed: %s (Reason: %s, Code: %s)", cmd, reason, code))
+    end
+end
+
 local function open_in_browser(url)
     local cmd
     if vim.fn.has("mac") == 1 then
@@ -50,7 +61,7 @@ local function open_in_browser(url)
         error("Spotify Auth: Unsupported OS")
     end
 
-    os.execute(cmd)
+    safe_execute(cmd)
 end
 
 ---@param client_id string
@@ -156,7 +167,7 @@ local function save_auth_tokens(
 )
     local http = require("plenary.curl")
     local redirect_uri_param = redirect_uri_port and
-    "&redirect_uri=" .. string.format(REDIRECT_URI_FORMAT, redirect_uri_port) or ""
+        "&redirect_uri=" .. string.format(REDIRECT_URI_FORMAT, redirect_uri_port) or ""
     local body = string.format(
         TOKEN_REQUEST_BODY_FORMAT,
         grant_type,

--- a/lua/spotify/auth.lua
+++ b/lua/spotify/auth.lua
@@ -141,14 +141,28 @@ end
 
 ---@return spotify.auth.Tokens | nil
 local function load_tokens()
-    local file = io.open(TOKEN_PATH, "r")
+    local file, err = io.open(TOKEN_PATH, "r")
     if not file then
+        vim.notify(
+            "Failed to open token file: " .. (err or "unknown error"),
+            vim.log.levels.ERROR
+        )
         return nil
     end
 
     local content = file:read("*a")
     file:close()
-    return vim.fn.json_decode(content)
+
+    local ok, tokens = pcall(vim.fn.json_decode, content)
+    if not ok then
+        vim.notify(
+            "Failed to decode token file: " .. tokens, -- error message is from `pcall`.
+            vim.log.levels.ERROR
+        )
+        return nil
+    end
+
+    return tokens
 end
 
 ---@param grant_type string


### PR DESCRIPTION
- **replace os.execute() with a safer variant**
- **log any errors in opening the token file**

Two quick additions to handle errors more gracefully, should they ever occur. I've ran into an issue with unix permissions, which I think would be caught by the `load_tokens` additions.

Untested right now, I'll test the changes shortly but feedback welcome regardless.